### PR TITLE
Make ⌚️ working

### DIFF
--- a/SmileTests/Tests.swift
+++ b/SmileTests/Tests.swift
@@ -81,6 +81,7 @@ class Tests: XCTestCase {
     XCTAssertEqual(Smile.extractEmojis(string: "Find ☀️and⚙️"), "☀️⚙️")
     XCTAssertEqual(Smile.extractEmojis(string: "Find the solos ⌨️ and ⭐️"), "⌨️⭐️")
     XCTAssertEqual(Smile.extractEmojis(string: "Find the 👨‍✈️👨‍🏫💂 and 👨‍💻"), "👨‍✈️👨‍🏫💂👨‍💻")
+    XCTAssertEqual(Smile.extractEmojis(string: "⌚️"), "⌚️")
   }
 
   func testRemoveEmoji() {

--- a/Sources/Emoji.swift
+++ b/Sources/Emoji.swift
@@ -734,7 +734,7 @@ public let emojiList: [String: String] = [
   "milky_way": "🌌",
   "bridge_at_night": "🌉",
   "foggy": "🌁",
-  "watch": "⌚️",
+  "watch": "⌚",
   "iphone": "📱",
   "calling": "📲",
   "computer": "💻",

--- a/Sources/Smile.swift
+++ b/Sources/Smile.swift
@@ -23,8 +23,8 @@ public func list() -> [String] {
     return String(Character(UnicodeScalar($0)!))
   }
 
-  //⌨️⭐️
-  let solos = [0x2328, 0x2B50]
+  //⌚️⌨️⭐️
+  let solos = [0x231A, 0x2328, 0x2B50]
   all.append(contentsOf: solos.map({ String(Character(UnicodeScalar($0)!))}))
     
   return all


### PR DESCRIPTION
It makes the ⌚️ emoji working.

Basically I found a deeper issue with `Script/parser.js` I think we should clean the `item.emoji` in the `parse` function.

When I tried to flatten the item `watch` in `emojiList` I got `["⌚️", ""]` instead of just `["⌚️"]`.

So I manually fixed this one + added in the unicode `list()`.

I'll do a check on all emojis when I have some time.

Let me know if somebody can handle the `parser.js` modification.