### PR TITLE
First fix for issue #10

### DIFF
--- a/SmileTests/Tests.swift
+++ b/SmileTests/Tests.swift
@@ -82,12 +82,14 @@ class Tests: XCTestCase {
     XCTAssertEqual(Smile.extractEmojis(string: "Find the solos ⌨️ and ⭐️"), "⌨️⭐️")
     XCTAssertEqual(Smile.extractEmojis(string: "Find the 👨‍✈️👨‍🏫💂 and 👨‍💻"), "👨‍✈️👨‍🏫💂👨‍💻")
     XCTAssertEqual(Smile.extractEmojis(string: "⌚️"), "⌚️")
+    XCTAssertEqual(Smile.extractEmojis(string: "Hello ⏰⌛️💳 and 🆙."), "⏰⌛️💳🆙")
   }
 
   func testRemoveEmoji() {
     XCTAssertEqual(Smile.removeEmojis(string: "Find 🔑and🔎"), "Find and")
     XCTAssertEqual(Smile.removeEmojis(string: "Remove the 👨‍🏫"), "Remove the ")
     XCTAssertEqual(Smile.removeEmojis(string: "🥑🦈🏍🛴🤡🦋🥚🦐🦑👰🇬🇧🎅🤑👍🏿☔️☂️☃️☀️❗️💀☠️⚔️⚖️☁️"), "")
+    XCTAssertEqual(Smile.removeEmojis(string: "⏰⌛️💳🆙"), "")
 
     // Variation selectors
     XCTAssertEqual(Smile.removeEmojis(string: "👨‍✈️⚔️"), "")

--- a/Sources/Smile.swift
+++ b/Sources/Smile.swift
@@ -15,6 +15,7 @@ public func list() -> [String] {
   let ranges = [
     0x1F601...0x1F64F,
     0x2600...0x27B0,
+    0x23F0...0x23FA,
     0x1F680...0x1F6C0,
     0x1F170...0x1F251
   ]
@@ -24,7 +25,7 @@ public func list() -> [String] {
   }
 
   //⌚️⌨️⭐️
-  let solos = [0x231A, 0x2328, 0x2B50]
+  let solos = [0x231A, 0x231B, 0x2328, 0x2B50]
   all.append(contentsOf: solos.map({ String(Character(UnicodeScalar($0)!))}))
     
   return all


### PR DESCRIPTION
Regarding issue #10 

When I tried
```swift
XCTAssertEqual(Smile.extractEmojis(string: "Hello ⏰⌛️💳🆙."), "⏰⌛️💳🆙")
```
I got
```
XCTAssertEqual failed: ("⏰️💳🆙") is not equal to ("⏰⌛️💳🆙")
```

So only ⌛️  seems to bug for now.

I fixed adding `0x231B`, which is ⌛️, in the list. 

I also added the range `0x23F0...0x23FA`

which at least includes
```
⏳ Hourglass Not Done | U+23F3
⏰ Alarm Clock | U+23F0
⏱️ Stopwatch | U+23F1, U+FE0F
⏲️ Timer Clock | U+23F2, U+FE0F
⏸️ Pause Button | U+23F8, U+FE0F
⏹️ Stop Button | U+23F9, U+FE0F
⏺️ Record Button | U+23FA, U+FE0F
```



