### PR TITLE
Fix parser to fetch Emojis

### DIFF
--- a/Script/parser.js
+++ b/Script/parser.js
@@ -18,55 +18,52 @@ function download(url, callback) {
 	  	callback(null);
 	});
 }
+var categories = {};
 
 download('https://cdn.rawgit.com/github/gemoji/master/db/emoji.json', function(data) {
-	parse(data);
-});
-
-download('https://cdn.rawgit.com/github/gemoji/master/db/Category-Emoji.json', function(data) {
-  parse_categories(data);
+  parse(data);
+  parse_categories();
 });
 
 function parse(data) {
   const json = JSON.parse(data);
 
   var string = 'public let emojiList: [String: String] = [\n'
-  for (var i=0; i<json.length; ++i) {
-    const item = json[i];
 
+  json.forEach(function(item){    
     if (typeof item.aliases === "undefined"
     || typeof item.emoji === "undefined"
     || item.emoji == "undefined") {
-      continue;
+      return;
     }
-
+    
     const itemString = '  "' + item.aliases[0] + '": "' + item.emoji + '",\n'
     string = string + itemString
-  }
-
+    
+    if (!categories[item.category]) {
+      categories[item.category] = []
+    } 
+    categories[item.category].push(item.emoji);
+  })
+  
   string = string + ']'
 
-  fs.writeFile('../Sources/Emoji.swift', string);
+  fs.writeFileSync('../Sources/Emoji.swift', string);
 };
 
 
-function parse_categories(data) {
-  const json = JSON.parse(data)["EmojiDataArray"];
-
-  var string = 'public let emojiCategories: [String: [String]] = [\n'
-  for (var i=0; i<json.length; ++i) {
-    const item = json[i];
-
-		const category = item["CVDataTitle"].split("-").slice(-1).pop().toLowerCase();
-		const emojis = item["CVCategoryData"]["Data"].split(",").map(function(emoji) {
+function parse_categories() {
+  var string = 'public let emojiCategories: [String: [String]] = [\n'  
+  Object.keys(categories).forEach(function(category) {    
+    const emojis = categories[category].map(function(emoji) {
 			return '"' + emoji + '"';
 		}).join(",");
 
     const itemString = '  "' + category + '": [' + emojis + '],\n'
     string = string + itemString
-  }
-
+  });
+  
   string = string + ']'
 
-	fs.writeFile('../Sources/Categories.swift', string);
+	fs.writeFileSync('../Sources/Categories.swift', string);
 };

--- a/Smile.podspec
+++ b/Smile.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Smile"
   s.summary          = "Emoji in Swift"
-  s.version          = "2.0.0"
+  s.version          = "2.0.1"
   s.homepage         = "https://github.com/onmyway133/Smile"
   s.license          = 'MIT'
   s.author           = { "Khoa Pham" => "onmyway133@gmail.com" }
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.source_files = 'Sources/**/*'
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
 end

--- a/Smile.xcodeproj/project.pbxproj
+++ b/Smile.xcodeproj/project.pbxproj
@@ -261,11 +261,12 @@
 				TargetAttributes = {
 					D5B2E89E1C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 1020;
 					};
 					D5B2E8A81C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0810;
+						DevelopmentTeam = FC224894XG;
+						LastSwiftMigration = 1020;
 					};
 					D5C6293F1C3A7FAA007F7B7C = {
 						CreatedOnToolsVersion = 7.2;
@@ -280,6 +281,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = D5B2E8951C3A780C00C0327D;
@@ -512,6 +514,7 @@
 				PRODUCT_NAME = Smile;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -531,6 +534,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fantageek.Smile.Smile-iOS";
 				PRODUCT_NAME = Smile;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -538,12 +542,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = FC224894XG;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/SmileTests/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SmileTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -551,11 +557,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = FC224894XG;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/SmileTests/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SmileTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Smile.xcodeproj/project.pbxproj
+++ b/Smile.xcodeproj/project.pbxproj
@@ -265,7 +265,6 @@
 					};
 					D5B2E8A81C3A780C00C0327D = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = FC224894XG;
 						LastSwiftMigration = 1020;
 					};
 					D5C6293F1C3A7FAA007F7B7C = {
@@ -542,7 +541,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = FC224894XG;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/SmileTests/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -557,7 +556,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = FC224894XG;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/SmileTests/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
Merging this PR will make the following changes

- Migrate to Swift 5
- Change version number to `2.0.1`
- Fix the parser file to generate `Emoji.swift` and `Category.swift`, because the categories JSON is not found on the CDN.